### PR TITLE
CI: add GHA workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,91 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  run_tests:
+    # pull requests are a duplicate of a branch push if within the same repo.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+
+    name: Test IPython startup files
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env-name: ["2023-2.1-py310", "2023-2.1-py310-tiled"]
+      fail-fast: false
+    env:
+      TZ: America/New_York
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Set env vars
+        run: |
+          export REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}  # just the repo, as opposed to org/repo
+          echo "REPOSITORY_NAME=${REPOSITORY_NAME}" >> $GITHUB_ENV
+
+          export CONDA_PACKED_ENV="${{ matrix.env-name }}.tar.gz"
+          echo "CONDA_PACKED_ENV=${CONDA_PACKED_ENV}" >> $GITHUB_ENV
+
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }} with conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: ${{ env.REPOSITORY_NAME }}-${{ matrix.env-name }}
+          auto-update-conda: true
+          miniconda-version: "latest"
+          python-version: "3.10"
+          mamba-version: "*"
+          channels: conda-forge
+
+      - name: Install the package and its dependencies
+        run: |
+          set -vxeo pipefail
+          conda env list
+          mkdir -p ~/env/
+          cd ~/env/
+          wget "https://zenodo.org/record/8098505/files/${CONDA_PACKED_ENV}?download=1" -O "${CONDA_PACKED_ENV}"
+          tar -xvf "${CONDA_PACKED_ENV}"
+          conda activate $PWD
+          conda-unpack
+          # pip install ...
+
+          pip list
+          conda list
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.6.0
+
+      - name: Prepare databroker config
+        run: |
+          set -vxeuo pipefail
+          mkdir -v -p $HOME/.config/databroker/
+          cp -v configs/databroker/local.yml $HOME/.config/databroker/xpd-ldrd20-31.yml
+
+      - name: Test the code
+        run: |
+          set -vxeuo pipefail
+          # This is what IPython does internally to load the startup files:
+          command="
+          import os
+          import glob
+          ip = get_ipython()
+          startup_files = sorted(glob.glob(os.path.join(os.getcwd(), 'startup/*.py')))
+          if os.path.isfile('.ci/drop-in.py'):
+              startup_files.append('.ci/drop-in.py')
+          if not startup_files:
+              raise SystemExit(f'Cannot find any startup files in {os.getcwd()}')
+          for f in startup_files:
+              if not os.path.isfile(f):
+                  raise FileNotFoundError(f'File {f} cannot be found.')
+              print(f'Executing {f} in CI')
+              ip.parent._exec_file(f)"
+
+          ipython --profile=test -c "$command"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -70,11 +70,12 @@ jobs:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.6.0
 
-      - name: Prepare databroker config
+      - name: Config files
         run: |
           set -vxeuo pipefail
           mkdir -v -p $HOME/.config/databroker/
           cp -v configs/databroker/local.yml $HOME/.config/databroker/xpd-ldrd20-31.yml
+          sudo cp -v configs/kafka.yml /etc/bluesky/kafka.yml
 
       - name: Test the code
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,6 +35,17 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v3
 
+      - name: Config files
+        run: |
+          set -vxeuo pipefail
+          mkdir -v -p $HOME/.config/databroker/
+          cp -v configs/databroker/local.yml $HOME/.config/databroker/xpd-ldrd20-31.yml
+          sudo mkdir -v -p /etc/bluesky/
+          sudo cp -v configs/kafka.yml /etc/bluesky/kafka.yml
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.6.0
+
       - name: Set up Python ${{ matrix.python-version }} with conda
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -66,16 +77,6 @@ jobs:
 
           pip list
           conda list
-
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.6.0
-
-      - name: Config files
-        run: |
-          set -vxeuo pipefail
-          mkdir -v -p $HOME/.config/databroker/
-          cp -v configs/databroker/local.yml $HOME/.config/databroker/xpd-ldrd20-31.yml
-          sudo cp -v configs/kafka.yml /etc/bluesky/kafka.yml
 
       - name: Test the code
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,8 +38,17 @@ jobs:
       - name: Config files
         run: |
           set -vxeuo pipefail
+
+          # Databroker v0/v1 config:
           mkdir -v -p $HOME/.config/databroker/
           cp -v configs/databroker/local.yml $HOME/.config/databroker/xpd-ldrd20-31.yml
+
+          # Tiled profile config:
+          tiled_profiles_dir="$HOME/.config/tiled/profiles/"
+          mkdir -v -p ${tiled_profiles_dir}
+          cp -v configs/tiled/profiles.yml ${tiled_profiles_dir}/profiles.yml
+
+          # Bluesky-kafka config:
           sudo mkdir -v -p /etc/bluesky/
           sudo cp -v configs/kafka.yml /etc/bluesky/kafka.yml
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,7 +45,14 @@ jobs:
           mamba-version: "*"
           channels: conda-forge
 
-      - name: Install the package and its dependencies
+      - name: Cache conda pack file
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/env/${{ env.CONDA_PACKED_ENV }}
+          key: ${{ env.CONDA_PACKED_ENV }}
+
+      - name: Conda env
         run: |
           set -vxeo pipefail
           conda env list

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -51,7 +51,7 @@ jobs:
           conda env list
           mkdir -p ~/env/
           cd ~/env/
-          wget "https://zenodo.org/record/8098505/files/${CONDA_PACKED_ENV}?download=1" -O "${CONDA_PACKED_ENV}"
+          wget --progress=dot:giga "https://zenodo.org/record/8098505/files/${CONDA_PACKED_ENV}?download=1" -O "${CONDA_PACKED_ENV}"
           tar -xvf "${CONDA_PACKED_ENV}"
           conda activate $PWD
           conda-unpack

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Test the code
         run: |
           set -vxeuo pipefail
+          conda activate ~/env
           # This is what IPython does internally to load the startup files:
           command="
           import os

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,7 +78,9 @@ jobs:
           conda env list
           mkdir -p ~/env/
           cd ~/env/
-          wget --progress=dot:giga "https://zenodo.org/record/8098505/files/${CONDA_PACKED_ENV}?download=1" -O "${CONDA_PACKED_ENV}"
+          if [ ! -f "${CONDA_PACKED_ENV}" ]; then
+              wget --progress=dot:giga "https://zenodo.org/record/8098505/files/${CONDA_PACKED_ENV}?download=1" -O "${CONDA_PACKED_ENV}"
+          fi
           tar -xvf "${CONDA_PACKED_ENV}"
           conda activate $PWD
           conda-unpack

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -44,7 +44,7 @@ jobs:
           cp -v configs/databroker/local.yml $HOME/.config/databroker/xpd-ldrd20-31.yml
 
           # Tiled profile config:
-          tiled_profiles_dir="$HOME/.config/tiled/profiles/"
+          tiled_profiles_dir="$HOME/.config/tiled/profiles"
           mkdir -v -p ${tiled_profiles_dir}
           cp -v configs/tiled/profiles.yml ${tiled_profiles_dir}/profiles.yml
 

--- a/configs/databroker/local.yml
+++ b/configs/databroker/local.yml
@@ -1,0 +1,15 @@
+metadatastore:
+  module: databroker.headersource.mongo
+  class: MDS
+  config:
+    host: 'localhost'
+    port: 27017
+    database: 'metadatastore-local'
+    timezone: 'US/Eastern'
+assets:
+  module: databroker.assets.mongo
+  class: Registry
+  config:
+    host: 'localhost'
+    port: 27017
+    database: 'asset-registry-local'

--- a/configs/kafka.yml
+++ b/configs/kafka.yml
@@ -1,0 +1,5 @@
+abort_run_on_kafka_exception: false
+bootstrap_servers:
+  - localhost:9092
+runengine_producer_config:
+  security.protocol: PLAINTEXT

--- a/configs/tiled/profiles.yml
+++ b/configs/tiled/profiles.yml
@@ -1,0 +1,10 @@
+xpd-ldrd20-31:
+  direct:
+    authentication:
+      allow_anonymous_access: true
+    trees:
+    - tree: databroker.mongo_normalized:Tree.from_uri
+      path: /
+      args:
+        uri: mongodb://localhost:27017/metadatastore-local
+        asset_registry_uri: mongodb://localhost:27017/asset-registry-local


### PR DESCRIPTION
Based on examples from:
- https://github.com/NSLS-II-ARI/profile_sirepo_ari/blob/main/.github/workflows/testing.yml
- https://github.com/NSLS-II/profile-collection-ci/blob/main/.azure-templates/get-configs.yml

Uses the [`cache` action](https://github.com/actions/cache) to save the downloaded env file from Zenodo and reuse it for quicker execution.