### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Checkout the code
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Config files
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -55,10 +55,10 @@ jobs:
           sudo cp -v configs/kafka.yml /etc/bluesky/kafka.yml
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.6.0
+        uses: supercharge/mongodb-github-action@a16e87bbc3edc38021742a5f958831c905fe9f67 # 1.6.0
 
       - name: Set up Python ${{ matrix.python-version }} with conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@9f54435e0e72c53962ee863144e47a4b094bfd35 # v2
         with:
           activate-environment: ${{ env.REPOSITORY_NAME }}-${{ matrix.env-name }}
           auto-update-conda: true


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions to read-only
